### PR TITLE
http-agent iterator example logic correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Each time an instance of http-agent raises the 'next' event the agent is passed 
       httpAgent = require('path/to/http-agent/lib');
   
   var agent = httpAgent.create('graph.facebook.com', ['apple', 'facebook', 'google']),
-      addPage = false;
+      addPage = true;
   
   agent.addListener('next', function (e, agent) {
     if (addPage) {


### PR DESCRIPTION
I believe there is a typo/logic error in the http-agent iterator example in the README.  addPage should be initialized to 'true' so that the additional URL will be added to the list on the 'next' event.

Jim
