### PR TITLE
Added a simple cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ Each time an instance of http-agent raises the 'next' event the agent is passed 
   agent.start();
 </pre>
 
+## Cache 
+If you call the constructor with an option "cache", it will save the results in this folder, and on the subsequent calls read it from this cache instead of doing an http request.
+
+The cache never expires. If you want to clear the cache simply remove any file in this folder.
+If the cache folder doesn't exist, it tries to create it.
+
+<pre>
+  var sys = require('sys'),
+  httpAgent = require('path/to/http-agent/lib');
+  
+  var agent = httpAgent.create('graph.facebook.com', ['apple', 'facebook', 'google'],{'cache':'/tmp/http-agent'});
+
+{'cache':'/tmp/mep'}
+</pre>
 ## Run Tests
 <pre>
   vows test/*-test.js --spec

--- a/lib/http-agent.js
+++ b/lib/http-agent.js
@@ -1,3 +1,4 @@
+
 /*
  * http-agent.js: A simple agent for performing a sequence of http requests in node.js 
  *
@@ -5,13 +6,14 @@
  * MIT LICENSE
  *
  */
- 
+
 var events = require('events'),
     http = require('http'),
     path = require('path'),
     url = require('url'),
     util = require('util'),
-    request = require('request');
+    request = require('request'),
+    fs = require ('fs');
 
 exports.create = function (host, urls, options) {
   return new HttpAgent(host, urls, options);
@@ -19,7 +21,7 @@ exports.create = function (host, urls, options) {
 
 var HttpAgent = exports.HttpAgent = function (host, urls, options) {
   events.EventEmitter.call(this);
-  
+
   //
   // Arguments parsings. Valid usage:
   //
@@ -36,11 +38,11 @@ var HttpAgent = exports.HttpAgent = function (host, urls, options) {
   else if (typeof host === 'string') {
     options.host = host;
   }
-  
+
   if (urls && Array.isArray(urls)) {
     options.urls = urls;
   }
- 
+
   //
   // Setup some intelligent defaults
   //
@@ -49,19 +51,28 @@ var HttpAgent = exports.HttpAgent = function (host, urls, options) {
   this.port = 80;
   this.host = options.host || 'localhost';
   this.options = {};
-  
+
   //
   // Extract the `request` options which persist across
   // all HTTP requests made by this instance.
   //
   var self = this;
   ['headers', 'json', 'followRedirect', 'maxRedirects', 'encoding', 'timeout'].forEach(function (opt) {
-    if (options[opt]) {
+      if (options[opt]) {
       self.options[opt] = options[opt];
-    }
-  });
+      }
+      });
 
-  //
+  if(options['cache'] != undefined){
+    self.cache = options['cache'];
+    try {
+      var cache  = fs.lstatSync(self.cache);
+      console.log ("Using cache:"+self.cache);
+    } catch (e) {
+      console.log ("Creating cache:"+self.cache);
+      fs.mkdirSync (self.cache, 0744);
+    }
+  }
   // Configure "private" variables for internal
   // state management in `HttpAgent`
   //
@@ -70,11 +81,11 @@ var HttpAgent = exports.HttpAgent = function (host, urls, options) {
   this._unvisited = options.urls || [];
 
   this.addListener('error', function (e) {
-    //
-    // Suppress `uncaughtException` errors from 
-    // this instance.
-    //
-  });
+      //
+      // Suppress `uncaughtException` errors from 
+      // this instance.
+      //
+      });
 };
 
 //
@@ -83,25 +94,25 @@ var HttpAgent = exports.HttpAgent = function (host, urls, options) {
 util.inherits(HttpAgent, events.EventEmitter);
 
 HttpAgent.prototype.__defineGetter__('prevUrls', function () {
-  var self = this;
-  return this._visited.map(function (url) {
-    return path.join(self.host, url);
-  });
-});
+    var self = this;
+    return this._visited.map(function (url) {
+      return path.join(self.host, url);
+      });
+    });
 
 HttpAgent.prototype.__defineGetter__('nextUrls', function () {
-  var self = this;
-  return this._unvisited.map(function (url) {
-    return path.join(self.host, url);
-  });
-});
-  
+    var self = this;
+    return this._unvisited.map(function (url) {
+      return path.join(self.host, url);
+      });
+    });
+
 HttpAgent.prototype.addUrl = function(url) {
   if (url) {
     this._unvisited = this._unvisited.concat(url);
   }
 };
-  
+
 HttpAgent.prototype.start = function () {
   if (!this._running) {
     this._running = true;
@@ -116,7 +127,7 @@ HttpAgent.prototype.stop = function () {
     this.emit('stop', null, this);
   }
 };
-  
+
 HttpAgent.prototype.back = function () {
   if (this._running) {
     return this._visited.length == 0
@@ -124,7 +135,7 @@ HttpAgent.prototype.back = function () {
       : this.next(this._visited[0]);
   }
 };
-  
+
 HttpAgent.prototype.next = function (url) {
   if (this._running) {
     // If the URL passed in exists, remove it 
@@ -133,7 +144,7 @@ HttpAgent.prototype.next = function (url) {
     if (index !== -1) {
       this._unvisited = this._unvisited.splice(index, 1);  
     }
-    
+
     var shouldVisit = url || this._unvisited.length > 0;
 
     // TODO: Be more robust than just 'GET'
@@ -147,9 +158,36 @@ HttpAgent.prototype.next = function (url) {
   }
 };
 
+HttpAgent.prototype._fetchURL = function (url,options, cache_file) {
+  var self= this;
+  try {
+    request(options, function (err, response, body) {
+        if (err) {
+        return self.emit('next', err);
+        }
+
+        self.current = options;
+        self._visited.unshift(url);
+        self.response = response;
+        self.body = body;
+        if (cache_file != undefined ) {
+        fs.writeFile(cache_file, body, function (err) {
+          if (err) throw err;
+          return;
+          });
+        } 
+        self.emit('next', null, self);
+        });
+  }
+  catch (requestErr) {
+    self.emit('next', requestErr);
+  }
+};
+
 HttpAgent.prototype._makeRequest = function (url) {
+
   this.body = '';
-  
+
   // Try to create the request or dispatch the error
   try {
     var options = this._createOptions(url);
@@ -159,30 +197,37 @@ HttpAgent.prototype._makeRequest = function (url) {
     this.emit('stop', createErr);
     return;
   }
-  
+
   var self = this;
-  
-  try {
-    request(options, function (err, response, body) {
-      if (err) {
-        return self.emit('next', err);
-      }
-      
-      self.current = options;
-      self._visited.unshift(url);
-      self.response = response;
-      self.body = body;
-      self.emit('next', null, self);
-    });
+  if (this['cache'] != undefined ) {
+    var cache_file = this.cache + '/'+ 'http-agent_'+encodeURI(this.host+"_"+ url);
+    try {
+      //      var file  = fs.lstatSync(cache_file);
+      fs.readFile(cache_file, function(err, file) {
+          if(!err) {
+          self.current = options;
+          self._visited.unshift(url);
+          self.response = 'fetched from cache '+cache_file;
+          self.body = file;
+          self.emit('next', null, self);
+          return;
+          } else {
+          self._fetchURL (url,options,cache_file);
+          }
+          });
+
+    } catch (e) {
+      self._fetchURL (url,options,cache_file);
+    }
+  } else {
+    self._fetchURL (url,options,null);
   }
-  catch (requestErr) {
-    this.emit('next', requestErr);
-  }
+
 };
-  
+
 HttpAgent.prototype._createOptions = function (url) {
   var options; 
-  
+
   switch (typeof(url)) {
     case 'string':    options = { uri: 'http://' + this.host + '/' + url }; break;
     case 'object':    options = this._createComplexOptions(url); break;
@@ -190,38 +235,38 @@ HttpAgent.prototype._createOptions = function (url) {
     case 'undefined': throw new Error('Cannot request undefined URL');
     default:          throw new Error('Argument Error'); 
   }
-  
+
   return mixin({}, this.options, options);
 };
-  
+
 HttpAgent.prototype._createComplexOptions = function (options) {
   if (typeof options.uri === 'undefined') {
     throw new Error('uri is required on object based urls.');
   }
-  
+
   var parsedUri = url.parse(options.uri),
       protocol  = parsedUri.protocol || 'http:',
       host      = parsedUri.host || this.host,
       pathname  = parsedUri.pathname.charAt(0) === '/' ? parsedUri.pathname : '/' + parsedUri.pathname;
-  
+
   options.uri = protocol + '//' + host + pathname;
-  
+
   if (typeof parsedUri.query !== 'undefined' && parsedUri.query.length > 0) {
     options.uri = options.uri + '?' + parsedUri.query;
   }
-  
+
   return options;
 };
 
 function mixin (target) {
   var objs = Array.prototype.slice.call(arguments, 1);
   objs.forEach(function (o) {
-    Object.keys(o).forEach(function (k) {
-      if (! o.__lookupGetter__(k)) {
+      Object.keys(o).forEach(function (k) {
+        if (! o.__lookupGetter__(k)) {
         target[k] = o[k];
-      }
-    });
-  });
+        }
+        });
+      });
 
   return target;
 };

--- a/lib/http-agent.js
+++ b/lib/http-agent.js
@@ -200,7 +200,8 @@ HttpAgent.prototype._makeRequest = function (url) {
 
   var self = this;
   if (this['cache'] != undefined ) {
-    var cache_file = this.cache + '/'+ 'http-agent_'+encodeURI(this.host+"_"+ url);
+    var cache_file = this.cache + '/'+ 'http-agent_'+this.host+"_"+ url.replace(/\//g,'@');
+    console.log (cache_file);
     try {
       //      var file  = fs.lstatSync(cache_file);
       fs.readFile(cache_file, function(err, file) {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "keywords": ["http-agent", "iterator", "http", "webcrawler"],
   "dependencies": {
-    "request": "1.9.x"
+    "request": ">= 1.9.x"
   },
   "devDependencies": {
-    "vows": "0.5.x"
+    "vows": ">= 0.5.x"
   },
   "main": "./lib/http-agent",
   "scripts": { "test": "vows test/*-test.js --spec" },


### PR DESCRIPTION
With this option, the body of the requests are saved as files. The next calls are using these files instead of doing an http request, therefore speeding up the retrieval.

I'm using it during the development, speeding the tests greatly.
