### PR TITLE
Options are forgotten when set to false

### DIFF
--- a/lib/http-agent.js
+++ b/lib/http-agent.js
@@ -56,7 +56,7 @@ var HttpAgent = exports.HttpAgent = function (host, urls, options) {
   //
   var self = this;
   ['headers', 'json', 'followRedirect', 'maxRedirects', 'encoding', 'timeout'].forEach(function (opt) {
-    if (options[opt]) {
+    if (typeof(options[opt]) != 'undefined') {
       self.options[opt] = options[opt];
     }
   });


### PR DESCRIPTION
When for example the followRedirect option is set to false, it is forgotten and request uses its default value of true.
