### PR TITLE
Returning agent on request error

### DIFF
--- a/lib/http-agent.js
+++ b/lib/http-agent.js
@@ -165,7 +165,7 @@ HttpAgent.prototype._makeRequest = function (url) {
   try {
     request(options, function (err, response, body) {
       if (err) {
-        return self.emit('next', err);
+        return self.emit('next', err, self);
       }
       
       self.current = options;


### PR DESCRIPTION
If there was an error during the request of an url, I still want to continue processing the other ones doing agent.next()
